### PR TITLE
Add note about depending font

### DIFF
--- a/README.rd
+++ b/README.rd
@@ -18,6 +18,9 @@ The Rabbit theme for ClearCode Inc.
 
   gem install rabbit-theme-clear-code
 
+And this theme depends on the font "Motoya L Maruberi" ("モトヤLマルベリ" in Japanese).
+You should install it for your platform, e.g. `sudo apt install fonts-motoya-l-maruberi` on Ubuntu.
+
 === Show
 
   rabbit -t rabbit-theme-clear-code rabbit-theme-benchmark-en.gem


### PR DESCRIPTION
フォントに言及がなかったため、自分は必要なフォントをインストールしそびれたまま利用してしまっていました。
フォントのインストールの案内があると、このような事故が減るのではないかと思いますが、いかがでしょうか？
